### PR TITLE
Fix default export in src/firebase.js

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -19,4 +19,5 @@ const auth = getAuth(app);
 // Get a reference to the firebase realtime database service
 const database = getDatabase(app);
 
-export { db, auth, database };
+export default app; // Default export for Firebase app
+export { db, auth, database }; // Named exports


### PR DESCRIPTION
@AmanRehan you were not exporting the *firebase app context* by default.
The issue has now been fixed.

Please see the new addition for 
`export default app`

Files changed:
1. `src/firebase.js`